### PR TITLE
feat: categories in product

### DIFF
--- a/prisma/migrations/20250329003335_category/migration.sql
+++ b/prisma/migrations/20250329003335_category/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `category` to the `products` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "products" ADD COLUMN     "category" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model Product {
   name            String
   price           Float
   currency        String
+  category        String
   countryOfOrigin String
   amazonLink      String
   walmartLink     String


### PR DESCRIPTION
This pull request includes changes to the database schema and the `Product` model to add a new `category` field. The most important changes include adding a required `category` column to the `products` table and updating the `Product` model in the Prisma schema.

Database schema changes:

* [`prisma/migrations/20250329003335_category/migration.sql`](diffhunk://#diff-753819d389e4d674cc0277f25e0cba4471cb8500b8635bbcf005181e95ab1f84R1-R8): Added a required `category` column to the `products` table without a default value.

Model updates:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR74): Added a `category` field to the `Product` model.