### PR TITLE
fix: schema id -> string

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model VerificationToken {
 }
 
 model Product {
-  id              Int    @id @default(autoincrement())
+  id              String @id @default(cuid())
   name            String
   price           Float
   currency        String
@@ -77,7 +77,7 @@ model Product {
   walmartLink     String
 
   // Self-referencing relation
-  alternativeProductId Int?     @map("alternative_product_id")
+  alternativeProductId String?  @map("alternative_product_id")
   alternativeProduct   Product? @relation("AlternativeProduct", fields: [alternativeProductId], references: [id], onDelete: SetNull)
 
   // Inverse relation (not necessary, but helpful if you want to query which products refer to this one)
@@ -87,7 +87,7 @@ model Product {
 }
 
 model Analytics {
-  id                       Int      @id @default(autoincrement())
+  id                       String   @id @default(cuid())
   month                    Int // 1 to 12
   year                     Int
   totalExpense             Float // total money spent


### PR DESCRIPTION
This pull request includes changes to the `prisma/schema.prisma` file to update the data types of certain model fields. The most important changes are the following:

Data type updates:

* [`model Product`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL70-R70): Changed the `id` field from `Int` to `String` and updated the default value to `cuid()`.
* [`model Product`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL80-R80): Changed the `alternativeProductId` field from `Int?` to `String?`.
* [`model Analytics`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL90-R90): Changed the `id` field from `Int` to `String` and updated the default value to `cuid()`.