### PR TITLE
fix: product schema with features and pros, cons

### DIFF
--- a/prisma/migrations/20250329010238_product/migration.sql
+++ b/prisma/migrations/20250329010238_product/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - The primary key for the `analytics` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `products` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `alternative_product_id` on the `products` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "products" DROP CONSTRAINT "products_alternative_product_id_fkey";
+
+-- AlterTable
+ALTER TABLE "analytics" DROP CONSTRAINT "analytics_pkey",
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "analytics_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "analytics_id_seq";
+
+-- AlterTable
+ALTER TABLE "products" DROP CONSTRAINT "products_pkey",
+DROP COLUMN "alternative_product_id",
+ADD COLUMN     "cons" TEXT[],
+ADD COLUMN     "organic" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "pros" TEXT[],
+ADD COLUMN     "rating" DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "id" SET DATA TYPE TEXT,
+ADD CONSTRAINT "products_pkey" PRIMARY KEY ("id");
+DROP SEQUENCE "products_id_seq";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,12 +76,11 @@ model Product {
   amazonLink      String
   walmartLink     String
 
-  // Self-referencing relation
-  alternativeProductId String?  @map("alternative_product_id")
-  alternativeProduct   Product? @relation("AlternativeProduct", fields: [alternativeProductId], references: [id], onDelete: SetNull)
-
-  // Inverse relation (not necessary, but helpful if you want to query which products refer to this one)
-  alternativeToProducts Product[] @relation("AlternativeProduct")
+  // New fields
+  pros    String[] // PostgreSQL supports arrays
+  cons    String[]
+  rating  Float    @default(0.0)
+  organic Boolean  @default(false)
 
   @@map("products")
 }


### PR DESCRIPTION
This pull request includes significant changes to the database schema and the Prisma model for the `products` and `analytics` tables. The most important changes include altering primary keys, dropping and adding columns, and updating the Prisma schema to reflect these changes.

Database schema changes:

* [`prisma/migrations/20250329010238_product/migration.sql`](diffhunk://#diff-96f021912065a2893cfb75de918d59ba763f5dcbcf43512869df6a83b196ed20R1-R29): Changed the primary key for the `analytics` table, altered the `id` column to use `TEXT` data type, and dropped the sequence `analytics_id_seq`.
* [`prisma/migrations/20250329010238_product/migration.sql`](diffhunk://#diff-96f021912065a2893cfb75de918d59ba763f5dcbcf43512869df6a83b196ed20R1-R29): Changed the primary key for the `products` table, dropped the `alternative_product_id` column, and added new columns `cons`, `organic`, `pros`, and `rating`. The `id` column was also altered to use `TEXT` data type, and the sequence `products_id_seq` was dropped.

Prisma schema changes:

* [`prisma/schema.prisma`](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL79-R83): Removed the self-referencing relation fields `alternativeProductId` and `alternativeProduct`, as well as the inverse relation `alternativeToProducts` from the `Product` model. Added new fields `pros`, `cons`, `rating`, and `organic` to the `Product` model.